### PR TITLE
Disable cache if block is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ lightly = Lightly.new
 lightly.clear 'example'
 ```
 
+If your block returns false or nil, the data will not be cached:
+
+```ruby
+result = cache.get 'test' do
+  false
+end
+
+puts cache.cached? 'test'
+# => false
+```
+
 ---
 
 For a similar gem that provides caching specifically for HTTP downloads,

--- a/lib/lightly/lightly.rb
+++ b/lib/lightly/lightly.rb
@@ -15,7 +15,7 @@ class Lightly
     return load key if cached?(key) && enabled?
 
     content = block.call
-    save key, content if enabled?
+    save key, content if content && enabled?
     content
   end
 

--- a/spec/lightly/lightly_spec.rb
+++ b/spec/lightly/lightly_spec.rb
@@ -30,6 +30,12 @@ describe Lightly do
       expect(Dir['cache/*']).to be_empty
     end
 
+    it "skips caching if block returns false" do
+      lightly.get('key') { false }
+      expect(Dir['cache/*']).to be_empty
+      expect(lightly.cached? 'key').to be false
+    end
+
     it "creates a cache folder" do
       expect(Dir).not_to exist 'cache'
       lightly.get('key') { 'content' }


### PR DESCRIPTION
This PR allows the user to prevent caching on a case by case basis, by simply returning `false` or `nil` from the block.

A typical use case can be to not cache if the HTTP request in the block returned a 404.